### PR TITLE
Consumer and publisher attributes from config

### DIFF
--- a/src/Owlery/Owlery/HostedServices/RabbitConnection.cs
+++ b/src/Owlery/Owlery/HostedServices/RabbitConnection.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Owlery.Models.Settings;
 using Owlery.Services;
+using Microsoft.Extensions.Configuration;
 
 namespace Owlery.HostedServices
 {
@@ -17,6 +18,7 @@ namespace Owlery.HostedServices
     {
         private readonly IDeclarationService declarationService;
         private readonly IServiceProvider serviceProvider;
+        private readonly IConfiguration configuration;
         private readonly OwlerySettings settings;
         private readonly ILogger logger;
         private readonly ILoggerFactory loggerFactory;
@@ -27,11 +29,13 @@ namespace Owlery.HostedServices
         public RabbitConnection(
             IDeclarationService declarationService,
             IServiceProvider serviceProvider,
+            IConfiguration configuration,
             IOptions<OwlerySettings> settings,
             ILoggerFactory factory)
         {
             this.declarationService = declarationService;
             this.serviceProvider = serviceProvider;
+            this.configuration = configuration;
             this.settings = settings.Value;
             this.logger = factory.CreateLogger<RabbitConnection>();
             this.loggerFactory = factory;
@@ -56,6 +60,7 @@ namespace Owlery.HostedServices
                     new RabbitConsumer(
                         consumerMethod,
                         model,
+                        this.configuration,
                         this.serviceProvider,
                         this.loggerFactory.CreateLogger<RabbitConsumer>()));
 

--- a/src/Owlery/Owlery/Models/Settings/OwlerySettings.cs
+++ b/src/Owlery/Owlery/Models/Settings/OwlerySettings.cs
@@ -10,8 +10,8 @@ namespace Owlery.Models.Settings
         public string HostName { get; set; }
         public int? Port { get; set; }
 
-        public List<QueueSettings> Queues { get; set; } = new List<QueueSettings>();
-        public List<ExchangeSettings> Exchanges { get; set; } = new List<ExchangeSettings>();
-        public List<BindingSettings> Bindings { get; set; } = new List<BindingSettings>();
+        public Dictionary<string, QueueSettings> Queues { get; set; } = new Dictionary<string, QueueSettings>();
+        public Dictionary<string, ExchangeSettings> Exchanges { get; set; } = new Dictionary<string, ExchangeSettings>();
+        public Dictionary<string, BindingSettings> Bindings { get; set; } = new Dictionary<string, BindingSettings>();
     }
 }

--- a/src/Owlery/Owlery/Services/DeclarationService.cs
+++ b/src/Owlery/Owlery/Services/DeclarationService.cs
@@ -18,13 +18,13 @@ namespace Owlery.Services
 
         public void DeclareAll(IModel model)
         {
-            foreach (var queueSettings in this.settings.Queues)
+            foreach (var queueSettings in this.settings.Queues.Values)
                 this.QueueDeclare(model, queueSettings);
 
-            foreach (var exchangeSettings in this.settings.Exchanges)
+            foreach (var exchangeSettings in this.settings.Exchanges.Values)
                 this.ExchangeDeclare(model, exchangeSettings);
 
-            foreach (var bindingSettings in this.settings.Bindings)
+            foreach (var bindingSettings in this.settings.Bindings.Values)
                 this.QueueBind(model, bindingSettings);
         }
 

--- a/src/Owlery/Owlery/Utils/ConfigurationFormatter.cs
+++ b/src/Owlery/Owlery/Utils/ConfigurationFormatter.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Configuration;
+
+namespace Owlery.Utils
+{
+    public class ConfigurationFormatter
+    {
+        public static string FormatWithConfig(string format, IConfiguration source)
+        {
+            if (format == null)
+                throw new ArgumentNullException("format");
+
+            Regex r = new Regex(@"(?<start>\{)+(?<property>.+)(?<end>\})+",
+                RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+            List<object> values = new List<object>();
+            string rewrittenFormat = r.Replace(format, delegate (Match m)
+            {
+                Group startGroup = m.Groups["start"];
+                Group propertyGroup = m.Groups["property"];
+                Group endGroup = m.Groups["end"];
+
+                values.Add(source.GetValue<string>(propertyGroup.Value));
+
+                return new string('{', startGroup.Captures.Count) + (values.Count - 1) + new string('}', endGroup.Captures.Count);
+            });
+
+            return string.Format(rewrittenFormat, values.ToArray());
+        }
+    }
+}

--- a/test/Owlery.Tests/Models/RabbitConsumer_RecievedEventHandler.cs
+++ b/test/Owlery.Tests/Models/RabbitConsumer_RecievedEventHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Owlery.Models;
@@ -49,6 +50,7 @@ namespace Owlery.Tests.Models
             var rabbitConsumer = new RabbitConsumer(
                 consumerMethod,
                 mockModel.Object,
+                null,
                 serviceCollection,
                 logger
             );
@@ -89,6 +91,7 @@ namespace Owlery.Tests.Models
             var rabbitConsumer = new RabbitConsumer(
                 consumerMethod,
                 mockModel.Object,
+                null,
                 serviceCollection,
                 logger
             );
@@ -141,6 +144,7 @@ namespace Owlery.Tests.Models
             var rabbitConsumer = new RabbitConsumer(
                 consumerMethod,
                 mockModel.Object,
+                null,
                 serviceCollection,
                 logger
             );
@@ -204,6 +208,7 @@ namespace Owlery.Tests.Models
             var rabbitConsumer = new RabbitConsumer(
                 consumerMethod,
                 mockModel.Object,
+                null,
                 serviceCollection,
                 logger
             );
@@ -273,6 +278,7 @@ namespace Owlery.Tests.Models
             var rabbitConsumer = new RabbitConsumer(
                 consumerMethod,
                 mockModel.Object,
+                null,
                 serviceCollection,
                 logger
             );
@@ -300,10 +306,158 @@ namespace Owlery.Tests.Models
             mockModel.VerifyNoOtherCalls();
         }
 
+        [Fact]
+        public void ShouldPublishToExchange()
+        {
+            // GIVEN - A consumer which will publish the returned value
+            var routingKey = "routingKey";
+            var exchangeName = "exchangeName";
+
+            var serviceCollectionFactory = new ServiceCollection();
+            // Make singleton so we can assert that the method ran
+            serviceCollectionFactory.AddSingleton<ConsumerController>(new ConsumerController(returnValue: "returnValue"));
+            serviceCollectionFactory.AddTransient<IByteConversionService, ByteConversionService>();
+            serviceCollectionFactory.AddTransient<IInvocationParameterService, InvocationParameterService>();
+
+            var serviceCollection = serviceCollectionFactory.BuildServiceProvider();
+
+            var consumerMethod = new ConsumerMethod(
+                typeof(ConsumerController).GetMethod("Consume"),
+                typeof(ConsumerController),
+                new RabbitConsumerAttribute(
+                    queueName: "consumerQueue",
+                    acknowledgementType: AcknowledgementType.AutoAck,
+                    nackOnException: true),
+                new RabbitPublisherAttribute(
+                    routingKey: routingKey,
+                    exchangeName: exchangeName
+                )
+            );
+
+            var mockModel = new Mock<IModel>();
+            var logger = TestLogger.CreateXUnit<RabbitConsumer>(this.output);
+
+            var eventArgs = new BasicDeliverEventArgs() {
+                DeliveryTag = 99
+            };
+
+            // WHEN - The consumer consumes a message
+            var rabbitConsumer = new RabbitConsumer(
+                consumerMethod,
+                mockModel.Object,
+                null,
+                serviceCollection,
+                logger
+            );
+            rabbitConsumer.RecievedEventHandler(null, eventArgs);
+
+            // THEN - Ack should be called but it will throw exception so nack will be called
+            var service = serviceCollection.GetRequiredService<ConsumerController>();
+            Assert.True(service.ConsumeCalled);
+
+            mockModel.Verify(m => m.BasicConsume(
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<EventingBasicConsumer>()
+                )
+            );
+            mockModel.Verify(m => m.BasicPublish(
+                It.Is<string>(s => s == exchangeName),
+                It.Is<string>(s => s == routingKey),
+                It.IsAny<bool>(),
+                It.IsAny<IBasicProperties>(),
+                It.IsAny<byte[]>()
+            ));
+            mockModel.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void ShouldPublishToConfiguredExchange()
+        {
+            // GIVEN - A consumer which will publish the returned value
+            var routingKeyConfigKey = "Config:Key:For:RoutingKey";
+            var routingKeyConfigVal = "routingKey";
+            var exchangeNameConfigKey = "Config:Key:For:ExchangeName";
+            var exchangeNameConfigVal = "exchangeName";
+            var configDict = new Dictionary<string, string>() {
+                {routingKeyConfigKey, routingKeyConfigVal},
+                {exchangeNameConfigKey, exchangeNameConfigVal}
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configDict)
+                .Build();
+
+            var serviceCollectionFactory = new ServiceCollection();
+            // Make singleton so we can assert that the method ran
+            serviceCollectionFactory.AddSingleton<ConsumerController>(new ConsumerController(returnValue: "returnValue"));
+            serviceCollectionFactory.AddTransient<IByteConversionService, ByteConversionService>();
+            serviceCollectionFactory.AddTransient<IInvocationParameterService, InvocationParameterService>();
+
+            var serviceCollection = serviceCollectionFactory.BuildServiceProvider();
+
+            var consumerMethod = new ConsumerMethod(
+                typeof(ConsumerController).GetMethod("Consume"),
+                typeof(ConsumerController),
+                new RabbitConsumerAttribute(
+                    queueName: "consumerQueue",
+                    acknowledgementType: AcknowledgementType.AutoAck,
+                    nackOnException: true),
+                new RabbitPublisherAttribute(
+                    routingKey: "{" + routingKeyConfigKey + "}",
+                    exchangeName: "{" + exchangeNameConfigKey + "}"
+                )
+            );
+
+            var mockModel = new Mock<IModel>();
+            var logger = TestLogger.CreateXUnit<RabbitConsumer>(this.output);
+
+            var eventArgs = new BasicDeliverEventArgs() {
+                DeliveryTag = 99
+            };
+
+            // WHEN - The consumer consumes a message
+            var rabbitConsumer = new RabbitConsumer(
+                consumerMethod,
+                mockModel.Object,
+                configuration,
+                serviceCollection,
+                logger
+            );
+            rabbitConsumer.RecievedEventHandler(null, eventArgs);
+
+            // THEN - Ack should be called but it will throw exception so nack will be called
+            var service = serviceCollection.GetRequiredService<ConsumerController>();
+            Assert.True(service.ConsumeCalled);
+
+            mockModel.Verify(m => m.BasicConsume(
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<IDictionary<string, object>>(),
+                    It.IsAny<EventingBasicConsumer>()
+                )
+            );
+            mockModel.Verify(m => m.BasicPublish(
+                It.Is<string>(s => s == exchangeNameConfigVal),
+                It.Is<string>(s => s == routingKeyConfigVal),
+                It.IsAny<bool>(),
+                It.IsAny<IBasicProperties>(),
+                It.IsAny<byte[]>()
+            ));
+            mockModel.VerifyNoOtherCalls();
+        }
+
         public class ConsumerController
         {
             private readonly bool ThrowException;
             public bool ConsumeCalled { get; set; }
+            public object ReturnValue { get; set; }
 
             public ConsumerController()
             {
@@ -317,11 +471,19 @@ namespace Owlery.Tests.Models
                 this.ThrowException = throwException;
             }
 
-            public void Consume()
+            public ConsumerController(object returnValue)
+            {
+                this.ConsumeCalled = false;
+                this.ThrowException = false;
+                this.ReturnValue = returnValue;
+            }
+
+            public object Consume()
             {
                 this.ConsumeCalled = true;
                 if (this.ThrowException)
                     throw new Exception("An exception");
+                return this.ReturnValue;
             }
         }
     }

--- a/test/Owlery.Tests/Services/DeclarationService_DeclareAll.cs
+++ b/test/Owlery.Tests/Services/DeclarationService_DeclareAll.cs
@@ -32,13 +32,16 @@ namespace Owlery.Tests.Services
             var arguments = new Dictionary<string, object>();
 
             var settings = new OwlerySettings {
-                Queues = new List<QueueSettings>() {
-                    new QueueSettings() {
-                        QueueName = queueName,
-                        Durable = durable,
-                        Exclusive = exclusive,
-                        AutoDelete = autoDelete,
-                        Arguments = arguments,
+                Queues = new Dictionary<string, QueueSettings>() {
+                    {
+                        "Queue",
+                        new QueueSettings() {
+                            QueueName = queueName,
+                            Durable = durable,
+                            Exclusive = exclusive,
+                            AutoDelete = autoDelete,
+                            Arguments = arguments,
+                        }
                     }
                 }
             };
@@ -74,13 +77,16 @@ namespace Owlery.Tests.Services
             var arguments = new Dictionary<string, object>();
 
             var settings = new OwlerySettings {
-                Exchanges = new List<ExchangeSettings>() {
-                    new ExchangeSettings() {
-                        ExchangeName = exchangeName,
-                        Type = type,
-                        Durable = durable,
-                        AutoDelete = autoDelete,
-                        Arguments = arguments,
+                Exchanges = new Dictionary<string, ExchangeSettings>() {
+                    {
+                        "Exchange",
+                        new ExchangeSettings() {
+                            ExchangeName = exchangeName,
+                            Type = type,
+                            Durable = durable,
+                            AutoDelete = autoDelete,
+                            Arguments = arguments,
+                        }
                     }
                 }
             };
@@ -115,12 +121,15 @@ namespace Owlery.Tests.Services
             var arguments = new Dictionary<string, object>();
 
             var settings = new OwlerySettings {
-                Bindings = new List<BindingSettings>() {
-                    new BindingSettings() {
-                        QueueName = queueName,
-                        ExchangeName = exchangeName,
-                        RoutingKey = routingKey,
-                        Arguments = arguments,
+                Bindings = new Dictionary<string, BindingSettings>() {
+                    {
+                        "Binding",
+                        new BindingSettings() {
+                            QueueName = queueName,
+                            ExchangeName = exchangeName,
+                            RoutingKey = routingKey,
+                            Arguments = arguments,
+                        }
                     }
                 }
             };


### PR DESCRIPTION
Consumer queue name, publisher exchange name and publisher routing key
can be gotten from configuration by surrounding the configuration key
with braces.

Fixes #1 