### PR TITLE
Bugfix: close channel after publish

### DIFF
--- a/src/Owlery/Owlery/Services/RabbitService.cs
+++ b/src/Owlery/Owlery/Services/RabbitService.cs
@@ -23,14 +23,16 @@ namespace Owlery.Services
             if (exchange == null)
                 exchange = "";
 
-            var model = rabbitConnection.GetModel();
-            model.BasicPublish(
-                exchange: exchange,
-                routingKey: routingKey,
-                mandatory: false,
-                basicProperties: null,
-                body: bodyBytes
-            );
+            using (var model = rabbitConnection.GetModel())
+            {
+                model.BasicPublish(
+                    exchange: exchange,
+                    routingKey: routingKey,
+                    mandatory: false,
+                    basicProperties: null,
+                    body: bodyBytes
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
GetModel in RabbitConnection returns a new channel which has to be
closed manually. This bug caused a buildup of channels. Added a using
statement for the new channel in the publish function.