### PR TITLE
Publication properties

### DIFF
--- a/src/Owlery/Owlery/Models/RabbitMessage.cs
+++ b/src/Owlery/Owlery/Models/RabbitMessage.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using RabbitMQ.Client;
+
+namespace Owlery.Models
+{
+    /// <summary>
+    /// Message to be published to a RabbitMQ exchange. Any properties with a
+    /// value other than null we override the basic properties of the channel.
+    /// </summary>
+    public class RabbitMessage
+    {
+        /// <summary>
+        /// The body of the message, will be converted to bytes using an
+        /// appropriate converter.
+        /// </summary>
+        public object Body { get; set; }
+
+        public string AppId { get; set; }
+        public string ClusterId { get; set; }
+        public string ContentEncoding { get; set; }
+        public string ContentType { get; set; }
+        public string CorrelationId { get; set; }
+        public byte? DeliveryMode { get; set; }
+        public string Expiration { get; set; }
+        public IDictionary<string, object> Headers { get; set; }
+        public string MessageId { get; set; }
+        public bool? Persistent { get; set; }
+        public byte? Priority { get; set; }
+        public string ReplyTo { get; set; }
+        public PublicationAddress ReplyToAddress { get; set; }
+        public AmqpTimestamp? Timestamp { get; set; }
+        public string Type { get; set; }
+        public string UserId { get; set; }
+
+        public RabbitMessage()
+        {
+
+        }
+
+        /// <summary>
+        /// Create a new message with a body.
+        /// </summary>
+        /// <param name="body">The body of the message, this will be converted
+        /// using an appropriate converter.</param>
+        public RabbitMessage(object body)
+        {
+            this.Body = body;
+        }
+    }
+}

--- a/src/Owlery/Owlery/Services/BasicPropertiesHandler.cs
+++ b/src/Owlery/Owlery/Services/BasicPropertiesHandler.cs
@@ -1,0 +1,30 @@
+using Owlery.Models;
+using RabbitMQ.Client;
+
+namespace Owlery.Services
+{
+    public class BasicPropertiesHandler : IBasicPropertiesHandler
+    {
+        public IBasicProperties ApplyMessageProperties(RabbitMessage message, IBasicProperties properties)
+        {
+            properties.AppId = message.AppId ?? properties.AppId;
+            properties.ClusterId = message.ClusterId ?? properties.ClusterId;
+            properties.ContentEncoding = message.ContentEncoding ?? properties.ContentEncoding;
+            properties.ContentType = message.ContentType ?? properties.ContentType;
+            properties.CorrelationId = message.CorrelationId ?? properties.CorrelationId;
+            properties.DeliveryMode = message.DeliveryMode ?? properties.DeliveryMode;
+            properties.Expiration = message.Expiration ?? properties.Expiration;
+            properties.Headers = message.Headers ?? properties.Headers;
+            properties.MessageId = message.MessageId ?? properties.MessageId;
+            properties.Persistent = message.Persistent ?? properties.Persistent;
+            properties.Priority = message.Priority ?? properties.Priority;
+            properties.ReplyTo = message.ReplyTo ?? properties.ReplyTo;
+            properties.ReplyToAddress = message.ReplyToAddress ?? properties.ReplyToAddress;
+            properties.Timestamp = message.Timestamp ?? properties.Timestamp;
+            properties.Type = message.Type ?? properties.Type;
+            properties.UserId = message.UserId ?? properties.UserId;
+
+            return properties;
+        }
+    }
+}

--- a/src/Owlery/Owlery/Services/IBasicPropertiesHandler.cs
+++ b/src/Owlery/Owlery/Services/IBasicPropertiesHandler.cs
@@ -1,0 +1,10 @@
+using Owlery.Models;
+using RabbitMQ.Client;
+
+namespace Owlery.Services
+{
+    public interface IBasicPropertiesHandler
+    {
+         IBasicProperties ApplyMessageProperties(RabbitMessage message, IBasicProperties properties);
+    }
+}

--- a/src/Owlery/Owlery/Services/IRabbitService.cs
+++ b/src/Owlery/Owlery/Services/IRabbitService.cs
@@ -1,9 +1,11 @@
+using Owlery.Models;
 using RabbitMQ.Client;
 
 namespace Owlery.Services
 {
     public interface IRabbitService
     {
-         void Publish(string routingKey, object body, string exchange = null, IBasicProperties basicProperties = null);
+         void Publish(object body, string routingKey, string exchange = null);
+         void Publish(RabbitMessage message, string routingKey, string exchange = null);
     }
 }

--- a/src/Owlery/Owlery/Services/RabbitService.cs
+++ b/src/Owlery/Owlery/Services/RabbitService.cs
@@ -1,4 +1,5 @@
 using Owlery.HostedServices;
+using Owlery.Models;
 using Owlery.Utils;
 using RabbitMQ.Client;
 
@@ -7,17 +8,22 @@ namespace Owlery.Services
     public class RabbitService : IRabbitService
     {
         private readonly RabbitConnection rabbitConnection;
+        private readonly IModel rabbitChannel;
         private readonly IByteConversionService byteConversionService;
+        private readonly IBasicPropertiesHandler basicPropertiesHandler;
 
         public RabbitService(
             RabbitConnection rabbitConnection,
-            IByteConversionService byteConversionService)
+            IByteConversionService byteConversionService,
+            IBasicPropertiesHandler basicPropertiesHandler)
         {
             this.rabbitConnection = rabbitConnection;
+            this.rabbitChannel = rabbitConnection.GetModel();
             this.byteConversionService = byteConversionService;
+            this.basicPropertiesHandler = basicPropertiesHandler;
         }
 
-        public void Publish(string routingKey, object body, string exchange = null, IBasicProperties basicProperties = null)
+        public void Publish(object body, string routingKey, string exchange = null)
         {
             var bodyBytes = this.byteConversionService.ConvertToByteArray(body);
 
@@ -26,6 +32,27 @@ namespace Owlery.Services
 
             using (var model = rabbitConnection.GetModel())
             {
+                model.BasicPublish(
+                    exchange: exchange,
+                    routingKey: routingKey,
+                    mandatory: false,
+                    basicProperties: null,
+                    body: bodyBytes
+                );
+            }
+        }
+
+        public void Publish(RabbitMessage message, string routingKey, string exchange = null)
+        {
+            var bodyBytes = this.byteConversionService.ConvertToByteArray(message.Body);
+
+            if (exchange == null)
+                exchange = "";
+
+            using (var model = rabbitConnection.GetModel())
+            {
+                var basicProperties = this.basicPropertiesHandler.ApplyMessageProperties(message, model.CreateBasicProperties());
+
                 model.BasicPublish(
                     exchange: exchange,
                     routingKey: routingKey,

--- a/test/Owlery.Tests/Services/BasicPropertiesHandler_ApplyMessageProperties.cs
+++ b/test/Owlery.Tests/Services/BasicPropertiesHandler_ApplyMessageProperties.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using Moq;
+using Owlery.Models;
+using Owlery.Services;
+using RabbitMQ.Client;
+using Xunit;
+
+namespace Owlery.Tests.Services
+{
+    public class BasicPropertiesHandler_ApplyMessageProperties
+    {
+        [Fact]
+        public void ShouldApplyNonNullProperties()
+        {
+            // GIVEN - a message to be applied to message properties
+            RabbitMessage message = new RabbitMessage {
+                AppId = "AppId",
+                Body = "Body",
+                ClusterId = "ClusterId",
+                ContentEncoding = "ContentEncoding",
+                ContentType = "ContentType",
+                CorrelationId = "CorrelationId",
+                DeliveryMode = 1,
+                Expiration = "Expiration",
+                Headers = new Dictionary<string, object>() { {"string", new object()} },
+                MessageId = "MessageId",
+                Persistent = true,
+                Priority = 2,
+                ReplyTo = "ReplyTo",
+                ReplyToAddress = new PublicationAddress("exchangeType", "exchangeName", "routingKey"),
+                Timestamp = new AmqpTimestamp(),
+                Type = "Type",
+                UserId = "UserId",
+            };
+
+            Mock<IBasicProperties> mockBasicProperties = new Mock<IBasicProperties>();
+
+            var handler = new BasicPropertiesHandler();
+
+            // WHEN - ApplyMessageProperties is run with the message and a mock basic properties
+            var properties = handler.ApplyMessageProperties(message, mockBasicProperties.Object);
+
+            // THEN - Each property of the rabbit message should be applied
+            mockBasicProperties.VerifySet(p => p.AppId = message.AppId);
+            mockBasicProperties.VerifySet(p => p.ClusterId = message.ClusterId);
+            mockBasicProperties.VerifySet(p => p.ContentEncoding = message.ContentEncoding);
+            mockBasicProperties.VerifySet(p => p.ContentType = message.ContentType);
+            mockBasicProperties.VerifySet(p => p.CorrelationId = message.CorrelationId);
+            mockBasicProperties.VerifySet(p => p.DeliveryMode = message.DeliveryMode.Value);
+            mockBasicProperties.VerifySet(p => p.Expiration = message.Expiration);
+            mockBasicProperties.VerifySet(p => p.Headers = message.Headers);
+            mockBasicProperties.VerifySet(p => p.MessageId = message.MessageId);
+            mockBasicProperties.VerifySet(p => p.Persistent = message.Persistent.Value);
+            mockBasicProperties.VerifySet(p => p.Priority = message.Priority.Value);
+            mockBasicProperties.VerifySet(p => p.ReplyTo = message.ReplyTo);
+            mockBasicProperties.VerifySet(p => p.ReplyToAddress = message.ReplyToAddress);
+            mockBasicProperties.VerifySet(p => p.Timestamp = message.Timestamp.Value);
+            mockBasicProperties.VerifySet(p => p.Type = message.Type);
+            mockBasicProperties.VerifySet(p => p.UserId = message.UserId);
+            mockBasicProperties.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void ShouldNotApplyNullProperties()
+        {
+            // GIVEN - a message to be applied to message properties
+            RabbitMessage message = new RabbitMessage {
+                AppId = null,
+                Body = "Body",
+                ClusterId = null,
+                ContentEncoding = null,
+                ContentType = null,
+                CorrelationId = null,
+                DeliveryMode = null,
+                Expiration = null,
+                Headers = null,
+                MessageId = null,
+                Persistent = null,
+                Priority = null,
+                ReplyTo = null,
+                ReplyToAddress = null,
+                Timestamp = null,
+                Type = null,
+                UserId = null,
+            };
+
+            Mock<IBasicProperties> mockBasicProperties = new Mock<IBasicProperties>();
+
+            var handler = new BasicPropertiesHandler();
+
+            // WHEN - ApplyMessageProperties is run with the message and a mock basic properties
+            var properties = handler.ApplyMessageProperties(message, mockBasicProperties.Object);
+
+            // THEN - Each property of the rabbit message should be applied
+            mockBasicProperties.VerifySet(p => p.AppId = null);
+            mockBasicProperties.VerifyGet(p => p.AppId);
+            mockBasicProperties.VerifySet(p => p.ClusterId = null);
+            mockBasicProperties.VerifyGet(p => p.ClusterId);
+            mockBasicProperties.VerifySet(p => p.ContentEncoding = null);
+            mockBasicProperties.VerifyGet(p => p.ContentEncoding);
+            mockBasicProperties.VerifySet(p => p.ContentType = null);
+            mockBasicProperties.VerifyGet(p => p.ContentType);
+            mockBasicProperties.VerifySet(p => p.CorrelationId = null);
+            mockBasicProperties.VerifyGet(p => p.CorrelationId);
+            mockBasicProperties.VerifySet(p => p.DeliveryMode = 0);
+            mockBasicProperties.VerifyGet(p => p.DeliveryMode);
+            mockBasicProperties.VerifySet(p => p.Expiration = null);
+            mockBasicProperties.VerifyGet(p => p.Expiration);
+            mockBasicProperties.VerifySet(p => p.Headers = null);
+            mockBasicProperties.VerifyGet(p => p.Headers);
+            mockBasicProperties.VerifySet(p => p.MessageId = null);
+            mockBasicProperties.VerifyGet(p => p.MessageId);
+            mockBasicProperties.VerifySet(p => p.Persistent = false);
+            mockBasicProperties.VerifyGet(p => p.Persistent);
+            mockBasicProperties.VerifySet(p => p.Priority = 0);
+            mockBasicProperties.VerifyGet(p => p.Priority);
+            mockBasicProperties.VerifySet(p => p.ReplyTo = null);
+            mockBasicProperties.VerifyGet(p => p.ReplyTo);
+            mockBasicProperties.VerifySet(p => p.ReplyToAddress = null);
+            mockBasicProperties.VerifyGet(p => p.ReplyToAddress);
+            mockBasicProperties.VerifySet(p => p.Timestamp = new AmqpTimestamp(0));
+            mockBasicProperties.VerifyGet(p => p.Timestamp);
+            mockBasicProperties.VerifySet(p => p.Type = null);
+            mockBasicProperties.VerifyGet(p => p.Type);
+            mockBasicProperties.VerifySet(p => p.UserId = null);
+            mockBasicProperties.VerifyGet(p => p.UserId);
+            mockBasicProperties.VerifyNoOtherCalls();
+        }
+    }
+}


### PR DESCRIPTION
When publishing messages via RabbitService you can now apply arbitrary
properties to the BasicProperties of the channel which will be forwarded
to the BasicPublish.